### PR TITLE
Changed Dependenices to junit 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,8 +77,6 @@ dependencies {
     testImplementation libs.junit.jupiter
     testImplementation libs.junit.jupiter.api
     testImplementation libs.junit
-    testImplementation libs.robolectric
-    testImplementation libs.robolectric.junit5
     testRuntimeOnly libs.junit.jupiter.engine
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,6 @@ tasks.register('jacocoTestReport', JacocoReport) {
     executionData.from = files("${project.layout.buildDirectory.get().asFile}/jacoco/testDebugUnitTest.exec")
 }
 
-
 sonar {
     properties {
         property "sonar.projectKey", "Group-B-DKT_DKT_Group_Beta"
@@ -73,10 +72,13 @@ dependencies {
     implementation libs.constraintlayout
     implementation libs.navigation.fragment
     implementation libs.navigation.ui
-    testImplementation libs.junit
     testImplementation libs.mockito.core
     testImplementation libs.robolectric
+    testImplementation libs.junit.jupiter
     testImplementation libs.junit.jupiter.api
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.robolectric.junit5
     testRuntimeOnly libs.junit.jupiter.engine
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core
@@ -84,5 +86,4 @@ dependencies {
     implementation libs.okhttp
     implementation libs.core
     compileOnly libs.lombok
-
 }

--- a/app/src/androidTest/java/com/example/dkt_group_beta/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/dkt_group_beta/ExampleInstrumentedTest.java
@@ -1,24 +1,20 @@
 package com.example.dkt_group_beta;
 
+
 import android.content.Context;
 
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.*;
+import junit.framework.TestCase;
 
 /**
  * Instrumented test, which will execute on an Android device.
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
-@RunWith(AndroidJUnit4.class)
-public class ExampleInstrumentedTest {
-    @Test
-    public void useAppContext() {
+public class ExampleInstrumentedTest extends TestCase {
+
+    public void testUseAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         assertEquals("com.example.dkt_group_beta", appContext.getPackageName());

--- a/app/src/androidTest/java/com/example/dkt_group_beta/io/CSVReaderTest.java
+++ b/app/src/androidTest/java/com/example/dkt_group_beta/io/CSVReaderTest.java
@@ -18,9 +18,9 @@ public class CSVReaderTest extends TestCase {
         fields = new ArrayList<>();
         context = ApplicationProvider.getApplicationContext();
     }
-
     public void testReadFields() throws IOException {
         fields = CSVReader.readFields(context);
         assertEquals(30, fields.size());
     }
+
 }

--- a/app/src/test/java/com/example/dkt_group_beta/communication/utilities/WrapperHelperTest.java
+++ b/app/src/test/java/com/example/dkt_group_beta/communication/utilities/WrapperHelperTest.java
@@ -15,60 +15,53 @@ import com.example.dkt_group_beta.communication.enums.Info;
 import com.example.dkt_group_beta.communication.enums.Request;
 import com.google.gson.Gson;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class WrapperHelperTest {
     private static Gson gson;
 
-    @BeforeAll
-    public static void setUp(){
+    @BeforeEach
+    public void setUp(){
         System.out.println("ASD");
         gson = new Gson();
     }
-
     @Test
-    public void getInstanceFromWrapperReturnNull(){
+    public void testGetInstanceFromWrapperReturnNull(){
         assertNull(WrapperHelper.getInstanceFromWrapper(new Wrapper(null, -1, Request.INFO, null)));
     }
-
     @Test
-    public void getInstanceFromWrapperConnectJsonObject(){
+    public void testGetInstanceFromWrapperConnectJsonObject(){
         ConnectJsonObject connectJsonObject = new ConnectJsonObject(ConnectType.NEW_CONNECT);
         Wrapper wrapper = new Wrapper(connectJsonObject.getClass().getSimpleName(), -1, Request.CONNECT, connectJsonObject);
         assertTrue(WrapperHelper.getInstanceFromWrapper(wrapper) instanceof ConnectJsonObject);
     }
-
     @Test
-    public void getInstanceFromWrapperReturnActionJsonObject(){
+    public void testGetInstanceFromWrapperReturnActionJsonObject(){
         ActionJsonObject actionJsonObject = new ActionJsonObject(Action.ROLL_DICE);
         Wrapper wrapper = new Wrapper(actionJsonObject.getClass().getSimpleName(), -1, Request.CONNECT, actionJsonObject);
         assertTrue(WrapperHelper.getInstanceFromWrapper(wrapper) instanceof ActionJsonObject);
     }
-
     @Test
-    public void getInstanceFromWrapperReturnInfoJsonObject(){
+    public void testGetInstanceFromWrapperReturnInfoJsonObject(){
         InfoJsonObject infoJsonObject = new InfoJsonObject(Info.GAME_LIST);
         Wrapper wrapper = new Wrapper(infoJsonObject.getClass().getSimpleName(), -1, Request.CONNECT, infoJsonObject);
         assertTrue(WrapperHelper.getInstanceFromWrapper(wrapper) instanceof InfoJsonObject);
     }
-
     @Test
-    public void getInstanceFromJsonReturnTrue(){
+    public void testGetInstanceFromJsonReturnTrue(){
         InfoJsonObject infoJsonObject = new InfoJsonObject(Info.GAME_LIST);
         Wrapper wrapper = new Wrapper(infoJsonObject.getClass().getSimpleName(), -1, Request.CONNECT, infoJsonObject);
         String json = gson.toJson(wrapper);
         assertTrue(WrapperHelper.getInstanceFromJson(json) instanceof InfoJsonObject);
     }
-
     @Test
-    public void getInstanceFromJsonReturnNull(){
+    public void testGetInstanceFromJsonReturnNull(){
         String json = "";
         assertNull(WrapperHelper.getInstanceFromJson(json));
     }
-
     @Test
-    public void toJsonFromObjectCorrect(){
+    public void testToJsonFromObjectCorrect(){
         ConnectJsonObject connectJsonObject = new ConnectJsonObject(ConnectType.NEW_CONNECT);
         Wrapper wrapper = new Wrapper(connectJsonObject.getClass().getSimpleName(), -1, Request.CONNECT, connectJsonObject);
         String expected = gson.toJson(wrapper);

--- a/app/src/test/java/com/example/dkt_group_beta/communication/utilities/WrapperHelperTest.java
+++ b/app/src/test/java/com/example/dkt_group_beta/communication/utilities/WrapperHelperTest.java
@@ -15,10 +15,12 @@ import com.example.dkt_group_beta.communication.enums.Info;
 import com.example.dkt_group_beta.communication.enums.Request;
 import com.google.gson.Gson;
 
+import junit.framework.TestCase;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class WrapperHelperTest {
+public class WrapperHelperTest extends TestCase {
     private static Gson gson;
 
     @BeforeEach

--- a/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
+++ b/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
@@ -1,43 +1,40 @@
 package com.example.dkt_group_beta.viewmodel;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import androidx.test.core.app.ApplicationProvider;
-
 import com.example.dkt_group_beta.activities.interfaces.LoginAction;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-@RunWith(RobolectricTestRunner.class)
+import org.robolectric.junit.jupiter.RobolectricExtension;
+
+@ExtendWith(RobolectricExtension.class)
 public class LoginViewModelTest {
     private Context context;
     private LoginAction loginAction;
     private LoginViewModel loginViewModel;
-
-
-    @Before
+    @BeforeEach
     public void setUp() {
 
-        context = ApplicationProvider.getApplicationContext();
+        context = RuntimeEnvironment.getApplication();
         loginViewModel = new LoginViewModel(context, loginAction);
     }
-
     @Test
     public void testgetSharedPreference() {
         try {
 
             LoginViewModel loginViewModel = new LoginViewModel(context, loginAction);
             SharedPreferences sharedPreferences = loginViewModel.getSharedPreference();
-            assertEquals(true, sharedPreferences != null);
+            assertNotNull(sharedPreferences);
         } catch (GeneralSecurityException | IOException e) {
             return;
         }

--- a/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
+++ b/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
@@ -9,15 +9,14 @@ import com.example.dkt_group_beta.activities.interfaces.LoginAction;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import org.robolectric.junit.jupiter.RobolectricExtension;
-
-@ExtendWith(RobolectricExtension.class)
+@RunWith(RobolectricTestRunner.class)
 public class LoginViewModelTest {
     private Context context;
     private LoginAction loginAction;

--- a/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
+++ b/app/src/test/java/com/example/dkt_group_beta/viewmodel/LoginViewModelTest.java
@@ -1,17 +1,18 @@
 package com.example.dkt_group_beta.viewmodel;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.example.dkt_group_beta.activities.interfaces.LoginAction;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -21,19 +22,22 @@ public class LoginViewModelTest {
     private Context context;
     private LoginAction loginAction;
     private LoginViewModel loginViewModel;
-    @BeforeEach
+
+
+    @Before
     public void setUp() {
 
-        context = RuntimeEnvironment.getApplication();
+        context = ApplicationProvider.getApplicationContext();
         loginViewModel = new LoginViewModel(context, loginAction);
     }
+
     @Test
     public void testgetSharedPreference() {
         try {
 
             LoginViewModel loginViewModel = new LoginViewModel(context, loginAction);
             SharedPreferences sharedPreferences = loginViewModel.getSharedPreference();
-            assertNotNull(sharedPreferences);
+            assertEquals(true, sharedPreferences != null);
         } catch (GeneralSecurityException | IOException e) {
             return;
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,6 @@ navigation-fragment = { group = "androidx.navigation", name = "navigation-fragme
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-robolectric-junit5 = { module = "org.robolectric:robolectric-junit5", version.ref = "robolectric" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.2"
+agp = "8.4.0"
 core = "1.5.0"
 gson = "2.10.1"
 junit = "4.13.2"
@@ -9,22 +9,23 @@ espressoCore = "3.5.1"
 appcompat = "1.6.1"
 lombok = "1.18.32"
 material = "1.11.0"
-activity = "1.8.2"
+activity = "1.9.0"
 constraintlayout = "2.1.4"
 mockitoCore = "5.7.0"
 navigationFragment = "2.7.7"
 navigationUi = "2.7.7"
 okhttp = "4.12.0"
-robolectric = "4.7.3"
+robolectric = "4.12.1"
 securityCrypto = "1.1.0-alpha06"
 
 [libraries]
 core = { module = "androidx.test:core", version.ref = "core" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+junit = { module = "junit:junit", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiterApi" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiterApi" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiterApi" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
@@ -36,6 +37,7 @@ navigation-fragment = { group = "androidx.navigation", name = "navigation-fragme
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+robolectric-junit5 = { module = "org.robolectric:robolectric-junit5", version.ref = "robolectric" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 18 16:22:51 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Ein Ansatz wäre, die Tests auf Junit 5 zu heben aus Kompatibilitätsgründen. Mit Roboelectric bei dem Login Test musste ich aber auf Junit 4 bleiben, da das irgendwie nicht geht. Prüfen kann ich das momentan aber nur schwer, da Sonarcloud nur neuen Code analysiert.